### PR TITLE
Add arm64 target_arch

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -49,6 +49,13 @@
                 }
               }
             ],
+            [
+              "target_arch=='arm64'", {
+                "variables": {
+                  "openssl_config_path": "<(nodedir)/deps/openssl/config/aarch64"
+                }
+              }
+            ],
           ],
           "include_dirs": [
             "<(nodedir)/deps/openssl/openssl/include",


### PR DESCRIPTION
This adds a missing target architecture for new Apple M1 machines which are `aarch64`. Fixes #13 

I tested this with

```
$ mkdir foo
$ cd foo
$ npm init -y
$ npm install github:cidem/eccrypto
```

and it finishes without errors.

With the upstream repo I get:

```
gyp: Undefined variable openssl_config_path in binding.gyp while trying to load binding.gyp
```